### PR TITLE
Add examples across more languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # 1Password Events API Generic Scripts
 
-To get started, replace `token` with your Events API token and `url` with the Events API URL corresponding to your 1Password account region.
+This repository contains scripts in several languages to get started with the Events API.
 
-Then run `python3 eventsapi.py`
+All scripts use the `EVENTS_API_TOKEN` environment variable to load your API token (and optionally `EVENTS_API_URL` for the API URL if not using `https://events.1password.com`). You should use [`op run`](https://developer.1password.com/docs/cli/reference/commands/run) and [secret references](https://developer.1password.com/docs/cli/secrets-reference-syntax/) provided by the [1Password CLI](https://developer.1password.com/docs/cli) to securely load environment variables.
+
+**Example 1** - using an `.env` file, running the PHP script:
+
+```shell
+op run --env-file .env -- php eventsapi.php
+```
+
+**Example 2** - providing variables inline, running the Go script:
+
+```shell
+EVENTS_API_TOKEN="op://Vault/Item/token" op run -- go run eventsapi.go
+```
+
+You can generate an API bearer token [online](https://support.1password.com/events-reporting/#appendix-issue-or-revoke-bearer-tokens) or through the [CLI](https://developer.1password.com/docs/cli/reference/management-commands/events-api#events-api-create).
 
 The script will print at most 20 sign in attempts and item usage events from the last 24 hours.
-
-Optionally, tools such as [jq](https://stedolan.github.io/jq/) can be used to format the ouput data.
 
 For more information, check out our support page [here](https://support.1password.com/events-reporting/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains scripts in several languages to get started with the Events API.
 
-All scripts use the `EVENTS_API_TOKEN` environment variable to load your API token (and optionally `EVENTS_API_URL` for the API URL if not using `https://events.1password.com`). You should use [`op run`](https://developer.1password.com/docs/cli/reference/commands/run) and [secret references](https://developer.1password.com/docs/cli/secrets-reference-syntax/) provided by the [1Password CLI](https://developer.1password.com/docs/cli) to securely load environment variables.
+All scripts use the `EVENTS_API_TOKEN` environment variable to load your API token. You should use [`op run`](https://developer.1password.com/docs/cli/reference/commands/run) and [secret references](https://developer.1password.com/docs/cli/secrets-reference-syntax/) provided by the [1Password CLI](https://developer.1password.com/docs/cli) to securely load environment variables.
 
 **Example 1** - using an `.env` file, running the PHP script:
 

--- a/eventsapi.go
+++ b/eventsapi.go
@@ -10,12 +10,12 @@ import (
 )
 
 func main() {
-	var api_token = "Bearer " + os.Getenv("EVENTS_API_TOKEN")
-	var url = "https://events.1password.com"
+	api_token := "Bearer " + os.Getenv("EVENTS_API_TOKEN")
+	url := "https://events.1password.com"
 
-	var start_time = time.Now().AddDate(0, 0, -24)
+	start_time := time.Now().AddDate(0, 0, -1)
 
-	var payload = []byte(fmt.Sprintf(`{
+	payload := []byte(fmt.Sprintf(`{
 		"limit": 20,
 		"start_time": "%s"
 	}`, start_time.Format(time.RFC3339)))

--- a/eventsapi.go
+++ b/eventsapi.go
@@ -20,15 +20,27 @@ func main() {
 		"start_time": "%s"
 	}`, start_time.Format(time.RFC3339)))
 
-	request, error := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/signinattempts", url), bytes.NewBuffer(payload))
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", api_token)
 	client := &http.Client{}
-	response, error := client.Do(request)
-	if error != nil {
-		panic(error)
+
+	signinsRequest, _ := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/signinattempts", url), bytes.NewBuffer(payload))
+	signinsRequest.Header.Set("Content-Type", "application/json")
+	signinsRequest.Header.Set("Authorization", api_token)
+	signinsResponse, signinsError := client.Do(signinsRequest)
+	if signinsError != nil {
+		panic(signinsError)
 	}
-	defer response.Body.Close()
-	body, _ := ioutil.ReadAll(response.Body)
-	fmt.Println(string(body))
+	defer signinsResponse.Body.Close()
+	signinsBody, _ := ioutil.ReadAll(signinsResponse.Body)
+	fmt.Println(string(signinsBody))
+
+	usagesRequest, _ := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/itemusages", url), bytes.NewBuffer(payload))
+	usagesRequest.Header.Set("Content-Type", "application/json")
+	usagesRequest.Header.Set("Authorization", api_token)
+	usagesResponse, usagesError := client.Do(usagesRequest)
+	if usagesError != nil {
+		panic(usagesError)
+	}
+	defer usagesResponse.Body.Close()
+	usagesBody, _ := ioutil.ReadAll(usagesResponse.Body)
+	fmt.Println(string(usagesBody))
 }

--- a/eventsapi.go
+++ b/eventsapi.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	var api_token = "Bearer " + os.Getenv("EVENTS_API_TOKEN")
+	var url = "https://events.1password.com"
+	if len(os.Getenv("EVENTS_API_URL")) > 0 {
+		url = os.Getenv("EVENTS_API_URL")
+	}
+
+	var start_time = time.Now().AddDate(0, 0, -24)
+
+	var payload = []byte(fmt.Sprintf(`{
+		"limit": 20,
+		"start_time": "%s"
+	}`, start_time.Format(time.RFC3339)))
+
+	request, error := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/signinattempts", url), bytes.NewBuffer(payload))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", api_token)
+	client := &http.Client{}
+	response, error := client.Do(request)
+	if error != nil {
+		panic(error)
+	}
+	defer response.Body.Close()
+	body, _ := ioutil.ReadAll(response.Body)
+	fmt.Println(string(body))
+}

--- a/eventsapi.go
+++ b/eventsapi.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	api_token := "Bearer " + os.Getenv("EVENTS_API_TOKEN")
+	api_token := os.Getenv("EVENTS_API_TOKEN")
 	url := "https://events.1password.com"
 
 	start_time := time.Now().AddDate(0, 0, -1)
@@ -24,7 +24,7 @@ func main() {
 
 	signinsRequest, _ := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/signinattempts", url), bytes.NewBuffer(payload))
 	signinsRequest.Header.Set("Content-Type", "application/json")
-	signinsRequest.Header.Set("Authorization", api_token)
+	signinsRequest.Header.Set("Authorization", "Bearer "+api_token)
 	signinsResponse, signinsError := client.Do(signinsRequest)
 	if signinsError != nil {
 		panic(signinsError)
@@ -35,7 +35,7 @@ func main() {
 
 	usagesRequest, _ := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/itemusages", url), bytes.NewBuffer(payload))
 	usagesRequest.Header.Set("Content-Type", "application/json")
-	usagesRequest.Header.Set("Authorization", api_token)
+	usagesRequest.Header.Set("Authorization", "Bearer "+api_token)
 	usagesResponse, usagesError := client.Do(usagesRequest)
 	if usagesError != nil {
 		panic(usagesError)

--- a/eventsapi.go
+++ b/eventsapi.go
@@ -12,9 +12,6 @@ import (
 func main() {
 	var api_token = "Bearer " + os.Getenv("EVENTS_API_TOKEN")
 	var url = "https://events.1password.com"
-	if len(os.Getenv("EVENTS_API_URL")) > 0 {
-		url = os.Getenv("EVENTS_API_URL")
-	}
 
 	var start_time = time.Now().AddDate(0, 0, -24)
 

--- a/eventsapi.js
+++ b/eventsapi.js
@@ -2,7 +2,7 @@
 // https://support.1password.com/events-reporting
 
 const apiToken = `Bearer ${process.env.EVENTS_API_TOKEN}`;
-const url = process.env.EVENTS_API_URL || "https://events.1password.com";
+const url = "https://events.1password.com";
 
 const startTime = new Date();
 startTime.setHours(startTime.getHours() - 24);

--- a/eventsapi.js
+++ b/eventsapi.js
@@ -1,7 +1,7 @@
 // For more information, check out our support page
 // https://support.1password.com/events-reporting
 
-const apiToken = `Bearer ${process.env.EVENTS_API_TOKEN}`;
+const apiToken = process.env.EVENTS_API_TOKEN;
 const url = "https://events.1password.com";
 
 const startTime = new Date();
@@ -9,7 +9,7 @@ startTime.setHours(startTime.getHours() - 24);
 
 const headers = {
   "Content-Type": "application/json",
-  "Authorization": apiToken
+  "Authorization": `Bearer ${apiToken}`
 };
 const payload = {
   "limit": 20,

--- a/eventsapi.js
+++ b/eventsapi.js
@@ -1,0 +1,45 @@
+// For more information, check out our support page
+// https://support.1password.com/events-reporting
+
+const apiToken = `Bearer ${process.env.EVENTS_API_TOKEN}`;
+const url = process.env.EVENTS_API_URL || "https://events.1password.com";
+
+const startTime = new Date();
+startTime.setHours(startTime.getHours() - 24);
+
+const headers = {
+  "Content-Type": "application/json",
+  "Authorization": apiToken
+};
+const payload = {
+  "limit": 20,
+  "start_time": startTime.toISOString().replace(/\.\d{3}Z$/, 'Z')
+};
+
+// Alternatively, use the cursor returned from previous responses to get any new events
+// payload = { "cursor": cursor }
+
+const options = {
+  method: 'POST',
+  body: JSON.stringify(payload),
+  headers,
+}
+
+fetch(`${url}/api/v1/signinattempts`, options).then(async (response) => {
+  if (response.ok) {
+    console.log(await response.json())
+  } else {
+    console.log("Error getting sign in attempts: status code", response.status);
+  }
+});
+
+fetch(`${url}/api/v1/itemusages`, options).then(async (response) => {
+  if (response.ok) {
+    console.log(await response.json())
+  } else {
+    console.log("Error getting item usages: status code", response.status);
+  }
+});
+
+// For more information on the response, check out our support page
+// https://support.1password.com/cs/events-api-reference/

--- a/eventsapi.php
+++ b/eventsapi.php
@@ -2,14 +2,14 @@
 # For more information, check out our support page
 # https://support.1password.com/events-reporting
 
-$api_token = "Bearer ".getenv('EVENTS_API_TOKEN');
+$api_token = getenv('EVENTS_API_TOKEN');
 $url = "https://events.1password.com";
 
 $start_time = (new \DateTime())->modify('-24 hours');
 
 $headers = array(
   "Content-Type: application/json",
-  "Authorization: $api_token"
+  "Authorization: Bearer $api_token"
 );
 $payload = array(
   "limit" => 20,

--- a/eventsapi.php
+++ b/eventsapi.php
@@ -3,11 +3,7 @@
 # https://support.1password.com/events-reporting
 
 $api_token = "Bearer ".getenv('EVENTS_API_TOKEN');
-$url = getenv('EVENTS_API_URL');
-
-if (!isset($url) || strlen($url) == 0) {
-  $url = "https://events.1password.com";
-}
+$url = "https://events.1password.com";
 
 $start_time = (new \DateTime())->modify('-24 hours');
 

--- a/eventsapi.php
+++ b/eventsapi.php
@@ -1,0 +1,43 @@
+<?php
+# For more information, check out our support page
+# https://support.1password.com/events-reporting
+
+$api_token = "Bearer ".getenv('EVENTS_API_TOKEN');
+$url = getenv('EVENTS_API_URL');
+
+if (!isset($url) || strlen($url) == 0) {
+  $url = "https://events.1password.com";
+}
+
+$start_time = (new \DateTime())->modify('-24 hours');
+
+$headers = array(
+  "Content-Type: application/json",
+  "Authorization: $api_token"
+);
+$payload = array(
+  "limit" => 20,
+  "start_time" => $start_time->format('Y-m-d\TH:i:s\Z')
+);
+
+# Alternatively, use the cursor returned from previous responses to get any new events
+# $payload = array("cursor" => $cursor);
+
+$context = stream_context_create(
+  array(
+    'http' => array(
+      'method' => 'POST',
+      'content' => json_encode($payload),
+      'header' => $headers,
+    )
+  )
+);
+
+$signin_attempts = file_get_contents($url."/api/v1/signinattempts", false, $context);
+print($signin_attempts);
+
+$item_usages = file_get_contents($url."/api/v1/itemusages", false, $context);
+print($item_usages);
+
+# For more information on the response, check out our support page
+# https://support.1password.com/cs/events-api-reference/

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -22,13 +22,13 @@ payload = {
 # Alternatively, use the cursor returned from previous responses to get any new events
 # payload = { "cursor": cursor }
 
-r = requests.post(url+"/api/v1/signinattempts", headers=headers, json=payload)
+r = requests.post(f"{url}/api/v1/signinattempts", headers=headers, json=payload)
 if (r.status_code == requests.codes.ok):
   print(r.json())
 else:
   print("Error getting sign in attempts: status code", r.status_code)
 
-r = requests.post(url+"/api/v1/itemusages", headers=headers, json=payload)
+r = requests.post(f"{url}/api/v1/itemusages", headers=headers, json=payload)
 if (r.status_code == requests.codes.ok):
   print(r.json())
 else:

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -6,7 +6,7 @@ import os
 # https://support.1password.com/events-reporting
 
 api_token = "Bearer "+os.environ['EVENTS_API_TOKEN']
-url = "https://events.1password.com" if not "EVENTS_API_URL" in os.environ else os.environ["EVENTS_API_URL"]
+url = "https://events.1password.com"
 
 start_time = datetime.datetime.now() - datetime.timedelta(hours=24)
 

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -5,7 +5,7 @@ import os
 # For more information, check out our support page
 # https://support.1password.com/events-reporting
 
-api_token = "Bearer "+os.environ['EVENTS_API_TOKEN']
+api_token = f"Bearer {os.environ['EVENTS_API_TOKEN']}"
 url = "https://events.1password.com"
 
 start_time = datetime.datetime.now() - datetime.timedelta(hours=24)

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -5,14 +5,14 @@ import os
 # For more information, check out our support page
 # https://support.1password.com/events-reporting
 
-api_token = f"Bearer {os.environ['EVENTS_API_TOKEN']}"
+api_token = os.environ['EVENTS_API_TOKEN']
 url = "https://events.1password.com"
 
 start_time = datetime.datetime.now() - datetime.timedelta(hours=24)
 
 headers = {
   "Content-Type": "application/json",
-  "Authorization": api_token
+  "Authorization": f"Bearer {api_token}"
 }
 payload = {
   "limit": 20,

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -1,42 +1,38 @@
 import datetime
 import requests
+import os
 
 # For more information, check out our support page
 # https://support.1password.com/events-reporting
 
-
-# Replace APITOKEN with your generated Events API token
-api_token = "Bearer APITOKEN"
-
-# Your URL corresponds to your 1Password account region
-url = "https://events.1password.com"
+api_token = "Bearer "+os.environ['EVENTS_API_TOKEN']
+url = "https://events.1password.com" if not "EVENTS_API_URL" in os.environ else os.environ["EVENTS_API_URL"]
 
 start_time = datetime.datetime.now() - datetime.timedelta(hours=24)
 
-header = {
-    "Content-Type": "application/json",
-    "Authorization": api_token
+headers = {
+  "Content-Type": "application/json",
+  "Authorization": api_token
 }
 payload = {
-    "limit": 20,
-    "start_time": start_time.astimezone().replace(microsecond=0).isoformat()
+  "limit": 20,
+  "start_time": start_time.astimezone().replace(microsecond=0).isoformat()
 }
 
 # Alternatively, use the cursor returned from previous responses to get any new events
-# payload = { "cursor" : cursor }
+# payload = { "cursor": cursor }
 
-r = requests.post(url+"/api/v1/signinattempts", headers=header, json=payload)
+r = requests.post(url+"/api/v1/signinattempts", headers=headers, json=payload)
 if (r.status_code == requests.codes.ok):
-    print(r.json())
+  print(r.json())
 else:
-    print("Error getting sign in attempts: status code", r.status_code)
+  print("Error getting sign in attempts: status code", r.status_code)
 
-r = requests.post(url+"/api/v1/itemusages", headers=header, json=payload)
+r = requests.post(url+"/api/v1/itemusages", headers=headers, json=payload)
 if (r.status_code == requests.codes.ok):
-    print(r.json())
+  print(r.json())
 else:
-    print("Error getting item usages: status code", r.status_code)
-
+  print("Error getting item usages: status code", r.status_code)
 
 # For more information on the response, check out our support page
 # https://support.1password.com/cs/events-api-reference/

--- a/eventsapi.rb
+++ b/eventsapi.rb
@@ -7,7 +7,7 @@ require 'uri'
 # https://support.1password.com/events-reporting
 
 api_token = ENV['EVENTS_API_TOKEN']
-url = ENV['EVENTS_API_URL'] || 'https://events.1password.com'
+url = 'https://events.1password.com'
 
 start_time = DateTime.now - 24
 

--- a/eventsapi.rb
+++ b/eventsapi.rb
@@ -1,0 +1,51 @@
+require 'date'
+require 'json'
+require 'net/http'
+require 'uri'
+
+# For more information, check out our support page
+# https://support.1password.com/events-reporting
+
+api_token = ENV['EVENTS_API_TOKEN']
+url = ENV['EVENTS_API_URL'] || 'https://events.1password.com'
+
+start_time = DateTime.now - 24
+
+headers = {
+  "Content-Type": "application/json",
+  "Authorization": "Bearer #{api_token}"
+}
+payload = {
+  "limit": 20,
+  "start_time": start_time.strftime("%FT%TZ")
+}
+
+# Alternatively, use the cursor returned from previous responses to get any new events
+# payload = { "cursor": cursor }
+
+uri = URI.parse(url+"/api/v1/signinattempts")
+http = Net::HTTP.new(uri.host, uri.port)
+http.use_ssl = true
+req = Net::HTTP::Post.new(uri.request_uri, headers)
+req.body = payload.to_json
+res = http.request(req)
+if (res.code == '200')
+  puts(JSON.parse(res.body))
+else
+  puts("Error getting sign in attempts: status code #{res.code}")
+end
+
+uri = URI.parse(url+"/api/v1/itemusages")
+http = Net::HTTP.new(uri.host, uri.port)
+http.use_ssl = true
+req = Net::HTTP::Post.new(uri.request_uri, headers)
+req.body = payload.to_json
+res = http.request(req)
+if (res.code == '200')
+  puts(JSON.parse(res.body))
+else
+  puts("Error getting item usages: status code #{res.code}")
+end
+
+# For more information on the response, check out our support page
+# https://support.1password.com/cs/events-api-reference/


### PR DESCRIPTION
I'm working on the [developer portal](https://developer.1password.com/), where we plan to one day embed the example script(s) from this repo in a doc page on working with the Events API, so this is my attempt to trying to expand the examples a bit 😄

This PR adds and updates generic events API scripts across multiple languages:

- Python
- JavaScript (Node)
- Ruby
- PHP
- Go

It also updates the Readme to encourage usage of the 1Password CLI and `op run` to inject secrets.

I have tested that all the scripts work, and I have made every attempt to get them mostly uniform in structure/functionality, but I'm really only good at JS so feedback on all the scripts is definitely welcome.

This is an unsolicited PR, so feel free to add commits to it as you see fit, or close altogether if you want to plan a more formal approach.