### PR TITLE
Add 1Password Events API Audit Events

### DIFF
--- a/eventsapi.go
+++ b/eventsapi.go
@@ -43,4 +43,15 @@ func main() {
 	defer usagesResponse.Body.Close()
 	usagesBody, _ := ioutil.ReadAll(usagesResponse.Body)
 	fmt.Println(string(usagesBody))
+
+	auditEventsRequest, _ := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/auditevents", url), bytes.NewBuffer(payload))
+	auditEventsRequest.Header.Set("Content-Type", "application/json")
+	auditEventsRequest.Header.Set("Authorization", "Bearer "+api_token)
+	auditEventsResponse, auditEventsError := client.Do(auditEventsRequest)
+	if auditEventsError != nil {
+		panic(auditEventsError)
+	}
+	defer auditEventsResponse.Body.Close()
+	auditEventsBody, _ := ioutil.ReadAll(auditEventsResponse.Body)
+	fmt.Println(string(auditEventsBody))
 }

--- a/eventsapi.js
+++ b/eventsapi.js
@@ -9,25 +9,25 @@ startTime.setHours(startTime.getHours() - 24);
 
 const headers = {
   "Content-Type": "application/json",
-  "Authorization": `Bearer ${apiToken}`
+  Authorization: `Bearer ${apiToken}`,
 };
 const payload = {
-  "limit": 20,
-  "start_time": startTime.toISOString().replace(/\.\d{3}Z$/, 'Z')
+  limit: 20,
+  start_time: startTime.toISOString().replace(/\.\d{3}Z$/, "Z"),
 };
 
 // Alternatively, use the cursor returned from previous responses to get any new events
 // payload = { "cursor": cursor }
 
 const options = {
-  method: 'POST',
+  method: "POST",
   body: JSON.stringify(payload),
   headers,
-}
+};
 
 fetch(`${url}/api/v1/signinattempts`, options).then(async (response) => {
   if (response.ok) {
-    console.log(await response.json())
+    console.log(await response.json());
   } else {
     console.log("Error getting sign in attempts: status code", response.status);
   }
@@ -35,9 +35,17 @@ fetch(`${url}/api/v1/signinattempts`, options).then(async (response) => {
 
 fetch(`${url}/api/v1/itemusages`, options).then(async (response) => {
   if (response.ok) {
-    console.log(await response.json())
+    console.log(await response.json());
   } else {
     console.log("Error getting item usages: status code", response.status);
+  }
+});
+
+fetch(`${url}/api/v1/auditevents`, options).then(async (response) => {
+  if (response.ok) {
+    console.log(await response.json());
+  } else {
+    console.log("Error getting audit events: status code", response.status);
   }
 });
 

--- a/eventsapi.php
+++ b/eventsapi.php
@@ -35,5 +35,8 @@ print($signin_attempts);
 $item_usages = file_get_contents($url."/api/v1/itemusages", false, $context);
 print($item_usages);
 
+$audit_events = file_get_contents($url."/api/v1/auditevents", false, $context);
+print($audit_events);
+
 # For more information on the response, check out our support page
 # https://support.1password.com/cs/events-api-reference/

--- a/eventsapi.py
+++ b/eventsapi.py
@@ -34,5 +34,11 @@ if (r.status_code == requests.codes.ok):
 else:
   print("Error getting item usages: status code", r.status_code)
 
+r = requests.post(f"{url}/api/v1/auditevents", headers=headers, json=payload)
+if (r.status_code == requests.codes.ok):
+  print(r.json())
+else:
+  print("Error getting audit events: status code", r.status_code)
+
 # For more information on the response, check out our support page
 # https://support.1password.com/cs/events-api-reference/

--- a/eventsapi.rb
+++ b/eventsapi.rb
@@ -47,5 +47,17 @@ else
   puts("Error getting item usages: status code #{res.code}")
 end
 
+uri = URI.parse(url+"/api/v1/auditevents")
+http = Net::HTTP.new(uri.host, uri.port)
+http.use_ssl = true
+req = Net::HTTP::Post.new(uri.request_uri, headers)
+req.body = payload.to_json
+res = http.request(req)
+if (res.code == '200')
+  puts(JSON.parse(res.body))
+else
+  puts("Error getting audit events: status code #{res.code}")
+end
+
 # For more information on the response, check out our support page
 # https://support.1password.com/cs/events-api-reference/


### PR DESCRIPTION
This PR adds a new audit events event stream to our scripts.

Note: A new Events API token has to be generated with the audit events scope/feature to be used here